### PR TITLE
some more additions to the scheduling page

### DIFF
--- a/04_Scheduling/02_Scheduler.md
+++ b/04_Scheduling/02_Scheduler.md
@@ -141,7 +141,7 @@ In order for this to happen, we need to modify our `schedule()` function a littl
 
 ```c
 cpu_status_t* schedule(cpu_status_t* context) {
-    processes_list[current_process_idx]->context = context;
+    processes_list[current_process_idx]->context = *context;
 
     do {
         current_process_idx = (current_process_idx++) % MAX_PROCESSES;
@@ -179,7 +179,7 @@ We'll modify our selection algorithm to take these new states into account:
 
 ```c
 cpu_status_t* schedule(cpu_status_t* context) {
-    processes_list[current_process_idx]->context = context;
+    processes_list[current_process_idx]->context = *context;
     processes_list[current_process_idx]->status = READY;
 
     do {

--- a/04_Scheduling/02_Scheduler.md
+++ b/04_Scheduling/02_Scheduler.md
@@ -221,6 +221,11 @@ void idle_main(void* arg) {
 
 The idle task is scheduled a little differently: it should only run when there is nothing else to run. You wouldn't want it to run when there is real work to do, because it's essentially throwing away a full quantum that could be used by another thread.
 
+## Troubleshooting
+### Interrupts stop after context switch
+Make sure to check the value of the flags register (rflags/eflags).  
+You might've set it to a value where the interrupt bit is cleared, causing the computer to disable hardware interrupts.
+
 ## Wrapping Up
 
 This chapter has covered everything needed to have a basic scheduler up and running. In the next chapter we'll look at creating and destroying processes. As mentioned this scheduler was written to be simple, not feature-rich. There are a number of ways you could improve upon it in your own design:

--- a/04_Scheduling/02_Scheduler.md
+++ b/04_Scheduling/02_Scheduler.md
@@ -221,8 +221,10 @@ void idle_main(void* arg) {
 
 The idle task is scheduled a little differently: it should only run when there is nothing else to run. You wouldn't want it to run when there is real work to do, because it's essentially throwing away a full quantum that could be used by another thread.
 
-## Troubleshooting
-### Interrupts stop after context switch
+### Troubleshooting
+
+#### Interrupts stop after context switch
+
 Make sure to check the value of the flags register (rflags/eflags).  
 You might've set it to a value where the interrupt bit is cleared, causing the computer to disable hardware interrupts.
 

--- a/04_Scheduling/02_Scheduler.md
+++ b/04_Scheduling/02_Scheduler.md
@@ -45,7 +45,7 @@ We'll delve into what exactly a process might need to contain in a separate chap
 ```c
 typedef struct {
     status_t process_status;
-    cpu_status_t context;
+    cpu_status_t* context;
 } process_t;
 ```
 
@@ -141,7 +141,7 @@ In order for this to happen, we need to modify our `schedule()` function a littl
 
 ```c
 cpu_status_t* schedule(cpu_status_t* context) {
-    processes_list[current_process_idx]->context = *context;
+    processes_list[current_process_idx]->context = context;
 
     do {
         current_process_idx = (current_process_idx++) % MAX_PROCESSES;
@@ -179,7 +179,7 @@ We'll modify our selection algorithm to take these new states into account:
 
 ```c
 cpu_status_t* schedule(cpu_status_t* context) {
-    processes_list[current_process_idx]->context = *context;
+    processes_list[current_process_idx]->context = context;
     processes_list[current_process_idx]->status = READY;
 
     do {
@@ -223,7 +223,7 @@ The idle task is scheduled a little differently: it should only run when there i
 
 ### Troubleshooting
 
-#### Interrupts stop after context switch
+#### Interrupts Stop After Context Switch
 
 Make sure to check the value of the flags register (rflags/eflags).  
 You might've set it to a value where the interrupt bit is cleared, causing the computer to disable hardware interrupts.


### PR DESCRIPTION
changes:
the code samples didn't dereference the context pointer when assigning it in the array of processes.
added a troubleshooting section and added a tip to make sure the rflags/eflags register is correctly set, as incorrectly setting it can cause the computer to disable interrupts and stop the timer.