### PR TITLE
Typo in the Free() page and a missing inline code

### DIFF
--- a/04_Memory_Management/05_Heap_Allocation.md
+++ b/04_Memory_Management/05_Heap_Allocation.md
@@ -134,7 +134,7 @@ The main problem with this algorithm is that we don't keep track of what we have
 
 Now we're going to build a new allocator based on the one we just implemented. The first thing to do is try to figure out what are the information we need to keep track of from the previous allocations:
 
-* Whenever we make an allocation we require x bytes of memory, so when we return the address, we know that the next free one will be at least at: `returned_address + x`  so we need to keep track of the allocation size.
+* Whenever we make an allocation we require `x` bytes of memory, so when we return the address, we know that the next free one will be at least at: `returned_address + x`  so we need to keep track of the allocation size.
 * Then we need a way to traverse to the previously allocated addresses, for this we need just a pointer to the start of the heap, if we decide to keep track of the sizes. 
 
 Now the problem is: how do we keep track of this information? 


### PR DESCRIPTION
Little typo in the section introducing the free() function.
Also one inline x was missing