### PR TITLE
Update ICW Values

### DIFF
--- a/02_Architecture/07_APIC.md
+++ b/02_Architecture/07_APIC.md
@@ -45,9 +45,9 @@ The old x86 architecture had two PIC processor, and they were called "master" an
 
 The ICW values are initialization commands (ICW stands for Initialization Command Words), every command word is one byte, and their meaning is:
 
-* ICW_1 (value `0x11`) is a word that indicates a start of initialization sequence, it is the same for both the master and slave pic.
+* ICW_1 (value `0x11`) is a word that indicates a start of initialization sequence, it is the same for both the master and slave PIC. (Bit 0 selects x86 mode, and bit 7 identifies the ICW_1.)
 * ICW_2 (value `0x20` for master, and `0x28` for slave) are just the interrupt vector address value (IDT entries), since the first 31 interrupts are used by the exceptions/reserved, we need to use entries above this value (remember that each pic has 8 different irqs that can handle.
-* ICW_3 (value `0x2` for master, `0x4` for slave) is used to indicate if the pin has a slave or not (since the slave pic will be connected to one of the interrupt pins of the master we need to indicate which one is), or in case of a slave device the value will be its id. On x86 architectures the master irq pin connected to the slave is the second, this is why the value of ICW_M is 2
+* ICW_3 (value `0x4` for master, `0x2` for slave) is used to indicate if the pin has a slave or not (since the slave pic will be connected to one of the interrupt pins of the master we need to indicate which one is), or in case of a slave device the value will be its id. On x86 architectures the master IRQ pin connected to the slave is the second, this is why the value of ICW_3_M is 1<<2, and ICW_3_S is 2.
 * ICW_4 contains some configuration bits for the mode of operation, in our case we just tell that we are going to use the 8086 mode.
 * Finally `0xFF` is used to mask all interrupts for the pic.
 


### PR DESCRIPTION
**NOTE: this should carefully be sanity checked by someone more knowledgeable in hardware.** 

We should be shifting by 2 instead of setting to 2 in the master ICW_3 to tell the master PIC the slave is on IRQ2. And thus the slave's ICW_3 should be setting, and not shifting. In my kernel, only masking seems to do anything; when I `sti` without masking the PIC's, I get immediate interrupt number 8 (what BIOS wires as master PIC's IRQ 0, which corresponds to the 8254 PIT). When I do mask, no problems, which tells me maybe this overkill because this "bug" went unnoticed.

Source 1: https://davmac.org/osdev/pchwpe/i8259.html
<img width="2350" height="696" alt="image" src="https://github.com/user-attachments/assets/b5a329d9-c792-4dfe-82b3-682fe4d6c6ec" />

Source 2: https://wiki.osdev.org/8259_PIC
```
// ICW3: tell Master PIC that there is a slave PIC at IRQ2
outb(PIC1_DATA, 1 << CASCADE_IRQ);
io_wait();
// ICW3: tell Slave PIC its cascade identity (0000 0010)
outb(PIC2_DATA, 2);
```

